### PR TITLE
Add chat completion endpoint for gpt5 nano

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,2 @@
+# OpenAI API Configuration
+OPENAI_API_KEY=your_openai_api_key_here

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # FastAPI Backend with OpenAI Integration
 
-A FastAPI backend with hello world and OpenAI chat completion endpoints.
+A FastAPI backend with hello world and OpenAI GPT-5 Nano chat completion endpoints.
 
 ## Features
 
@@ -71,7 +71,7 @@ Returns the health status of the API.
 ```
 
 ### POST /chat/completions
-Makes a chat completion request to OpenAI GPT-4.
+Makes a chat completion request to OpenAI GPT-5 Nano.
 
 **Request Body:**
 ```json
@@ -82,7 +82,7 @@ Makes a chat completion request to OpenAI GPT-4.
       "content": "Hello, how are you?"
     }
   ],
-  "model": "gpt-4",
+  "model": "gpt-5-nano",
   "max_tokens": 150,
   "temperature": 0.7
 }
@@ -92,7 +92,7 @@ Makes a chat completion request to OpenAI GPT-4.
 ```json
 {
   "message": "Hello! I'm doing well, thank you for asking. How can I help you today?",
-  "model": "gpt-4",
+  "model": "gpt-5-nano",
   "usage": {
     "prompt_tokens": 12,
     "completion_tokens": 17,
@@ -103,7 +103,7 @@ Makes a chat completion request to OpenAI GPT-4.
 
 **Parameters:**
 - `messages` (required): Array of chat messages with role ("user", "assistant", "system") and content
-- `model` (optional): OpenAI model to use (default: "gpt-4")
+- `model` (optional): OpenAI model to use (default: "gpt-5-nano")
 - `max_tokens` (optional): Maximum tokens in response (default: 150)
 - `temperature` (optional): Creativity/randomness (0.0-2.0, default: 0.7)
 

--- a/README.md
+++ b/README.md
@@ -1,19 +1,30 @@
-# Simple FastAPI Hello World Backend
+# FastAPI Backend with OpenAI Integration
 
-A simple FastAPI backend with a hello world endpoint.
+A FastAPI backend with hello world and OpenAI chat completion endpoints.
 
 ## Features
 
 - Hello World endpoint at `/`
 - Health check endpoint at `/health`
+- OpenAI chat completion endpoint at `/chat/completions`
 - Interactive API documentation (Swagger UI)
 - Automatic OpenAPI schema generation
+- Proper error handling and request validation
 
 ## Setup
 
 1. Install dependencies:
 ```bash
 pip install -r requirements.txt
+```
+
+2. Configure OpenAI API key:
+```bash
+# Copy the example environment file
+cp .env.example .env
+
+# Edit .env and add your OpenAI API key
+OPENAI_API_KEY=your_actual_openai_api_key_here
 ```
 
 ## Running the Application
@@ -31,6 +42,7 @@ uvicorn main:app --host 0.0.0.0 --port 8000 --reload
 The API will be available at:
 - **Main endpoint**: http://localhost:8000/
 - **Health check**: http://localhost:8000/health
+- **Chat completion**: http://localhost:8000/chat/completions
 - **Interactive docs (Swagger UI)**: http://localhost:8000/docs
 - **Alternative docs (ReDoc)**: http://localhost:8000/redoc
 - **OpenAPI schema**: http://localhost:8000/openapi.json
@@ -57,6 +69,43 @@ Returns the health status of the API.
   "message": "API is running"
 }
 ```
+
+### POST /chat/completions
+Makes a chat completion request to OpenAI GPT-4.
+
+**Request Body:**
+```json
+{
+  "messages": [
+    {
+      "role": "user",
+      "content": "Hello, how are you?"
+    }
+  ],
+  "model": "gpt-4",
+  "max_tokens": 150,
+  "temperature": 0.7
+}
+```
+
+**Response:**
+```json
+{
+  "message": "Hello! I'm doing well, thank you for asking. How can I help you today?",
+  "model": "gpt-4",
+  "usage": {
+    "prompt_tokens": 12,
+    "completion_tokens": 17,
+    "total_tokens": 29
+  }
+}
+```
+
+**Parameters:**
+- `messages` (required): Array of chat messages with role ("user", "assistant", "system") and content
+- `model` (optional): OpenAI model to use (default: "gpt-4")
+- `max_tokens` (optional): Maximum tokens in response (default: 150)
+- `temperature` (optional): Creativity/randomness (0.0-2.0, default: 0.7)
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -76,15 +76,12 @@ Makes a chat completion request to OpenAI GPT-5 Nano.
 **Request Body:**
 ```json
 {
-  "messages": [
-    {
-      "role": "user",
-      "content": "Hello, how are you?"
-    }
-  ],
+  "input": "Hello, how are you?",
   "model": "gpt-5-nano",
-  "max_tokens": 150,
-  "temperature": 0.7
+  "max_output_tokens": 150,
+  "temperature": 0.7,
+  "reasoning_effort": "medium",
+  "verbosity": "medium"
 }
 ```
 
@@ -97,15 +94,21 @@ Makes a chat completion request to OpenAI GPT-5 Nano.
     "prompt_tokens": 12,
     "completion_tokens": 17,
     "total_tokens": 29
-  }
+  },
+  "reasoning_effort": "medium",
+  "verbosity": "medium"
 }
 ```
 
 **Parameters:**
-- `messages` (required): Array of chat messages with role ("user", "assistant", "system") and content
+- `input` (required): The text input to be processed by the model
 - `model` (optional): OpenAI model to use (default: "gpt-5-nano")
-- `max_tokens` (optional): Maximum tokens in response (default: 150)
+- `max_output_tokens` (optional): Maximum tokens in response (default: 150)
 - `temperature` (optional): Creativity/randomness (0.0-2.0, default: 0.7)
+- `reasoning_effort` (optional): Depth of reasoning - "minimal", "low", "medium" (default), "high"
+- `verbosity` (optional): Response detail level - "low", "medium" (default), "high"
+- `top_p` (optional): Nucleus sampling parameter (0.0-1.0)
+- `stream` (optional): Stream response as it's generated (default: false)
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # FastAPI Backend with OpenAI Integration
 
-A FastAPI backend with hello world and OpenAI GPT-5 Nano chat completion endpoints.
+A FastAPI backend with hello world and OpenAI GPT-4o Mini chat completion endpoints.
 
 ## Features
 
@@ -71,17 +71,20 @@ Returns the health status of the API.
 ```
 
 ### POST /chat/completions
-Makes a chat completion request to OpenAI GPT-5 Nano.
+Makes a chat completion request to OpenAI GPT-4o Mini.
 
 **Request Body:**
 ```json
 {
-  "input": "Hello, how are you?",
-  "model": "gpt-5-nano",
-  "max_output_tokens": 150,
-  "temperature": 0.7,
-  "reasoning_effort": "medium",
-  "verbosity": "medium"
+  "messages": [
+    {
+      "role": "user",
+      "content": "Hello, how are you?"
+    }
+  ],
+  "model": "gpt-4o-mini",
+  "max_tokens": 150,
+  "temperature": 0.7
 }
 ```
 
@@ -89,26 +92,20 @@ Makes a chat completion request to OpenAI GPT-5 Nano.
 ```json
 {
   "message": "Hello! I'm doing well, thank you for asking. How can I help you today?",
-  "model": "gpt-5-nano",
+  "model": "gpt-4o-mini",
   "usage": {
     "prompt_tokens": 12,
     "completion_tokens": 17,
     "total_tokens": 29
-  },
-  "reasoning_effort": "medium",
-  "verbosity": "medium"
+  }
 }
 ```
 
 **Parameters:**
-- `input` (required): The text input to be processed by the model
-- `model` (optional): OpenAI model to use (default: "gpt-5-nano")
-- `max_output_tokens` (optional): Maximum tokens in response (default: 150)
+- `messages` (required): Array of chat messages with role ("user", "assistant", "system") and content
+- `model` (optional): OpenAI model to use (default: "gpt-4o-mini")
+- `max_tokens` (optional): Maximum tokens in response (default: 150)
 - `temperature` (optional): Creativity/randomness (0.0-2.0, default: 0.7)
-- `reasoning_effort` (optional): Depth of reasoning - "minimal", "low", "medium" (default), "high"
-- `verbosity` (optional): Response detail level - "low", "medium" (default), "high"
-- `top_p` (optional): Nucleus sampling parameter (0.0-1.0)
-- `stream` (optional): Stream response as it's generated (default: false)
 
 ## Development
 

--- a/main.py
+++ b/main.py
@@ -1,11 +1,86 @@
-from fastapi import FastAPI
+import os
+from typing import List, Optional
+from fastapi import FastAPI, HTTPException
+from pydantic import BaseModel
+from openai import OpenAI
+from dotenv import load_dotenv
+
+# Load environment variables
+load_dotenv()
 
 # Create FastAPI instance
 app = FastAPI(
-    title="Hello World API",
-    description="A simple FastAPI backend with a hello world endpoint",
+    title="Hello World API with OpenAI",
+    description="A FastAPI backend with hello world and OpenAI chat completion endpoints",
     version="1.0.0"
 )
+
+# Initialize OpenAI client
+client = OpenAI(api_key=os.getenv("OPENAI_API_KEY"))
+
+# Pydantic models
+class ChatMessage(BaseModel):
+    role: str
+    content: str
+
+class ChatCompletionRequest(BaseModel):
+    messages: List[ChatMessage]
+    model: Optional[str] = "gpt-4"
+    max_tokens: Optional[int] = 150
+    temperature: Optional[float] = 0.7
+
+class ChatCompletionResponse(BaseModel):
+    message: str
+    model: str
+    usage: dict
+
+@app.post("/chat/completions", response_model=ChatCompletionResponse)
+async def chat_completion(request: ChatCompletionRequest):
+    """
+    Chat completion endpoint using OpenAI GPT-4
+    Makes a single chat completion API request to OpenAI
+    """
+    try:
+        # Validate API key is configured
+        if not os.getenv("OPENAI_API_KEY"):
+            raise HTTPException(
+                status_code=500, 
+                detail="OpenAI API key not configured. Please set OPENAI_API_KEY environment variable."
+            )
+        
+        # Convert Pydantic models to dict format expected by OpenAI
+        messages = [{"role": msg.role, "content": msg.content} for msg in request.messages]
+        
+        # Make the OpenAI API call
+        response = client.chat.completions.create(
+            model=request.model,
+            messages=messages,
+            max_tokens=request.max_tokens,
+            temperature=request.temperature
+        )
+        
+        # Extract the response content
+        message_content = response.choices[0].message.content
+        
+        return ChatCompletionResponse(
+            message=message_content,
+            model=response.model,
+            usage={
+                "prompt_tokens": response.usage.prompt_tokens,
+                "completion_tokens": response.usage.completion_tokens,
+                "total_tokens": response.usage.total_tokens
+            }
+        )
+        
+    except Exception as e:
+        if "api_key" in str(e).lower():
+            raise HTTPException(status_code=401, detail="Invalid OpenAI API key")
+        elif "quota" in str(e).lower():
+            raise HTTPException(status_code=429, detail="OpenAI API quota exceeded")
+        elif "model" in str(e).lower():
+            raise HTTPException(status_code=400, detail=f"Invalid model specified: {request.model}")
+        else:
+            raise HTTPException(status_code=500, detail=f"OpenAI API error: {str(e)}")
 
 @app.get("/")
 async def hello_world():

--- a/main.py
+++ b/main.py
@@ -11,7 +11,7 @@ load_dotenv()
 # Create FastAPI instance
 app = FastAPI(
     title="Hello World API with OpenAI",
-    description="A FastAPI backend with hello world and OpenAI GPT-5 Nano chat completion endpoints",
+    description="A FastAPI backend with hello world and OpenAI GPT-4o Mini chat completion endpoints",
     version="1.0.0"
 )
 
@@ -19,27 +19,25 @@ app = FastAPI(
 client = OpenAI(api_key=os.getenv("OPENAI_API_KEY"))
 
 # Pydantic models
+class ChatMessage(BaseModel):
+    role: str
+    content: str
+
 class ChatCompletionRequest(BaseModel):
-    input: str
-    model: Optional[str] = "gpt-5-nano"
-    max_output_tokens: Optional[int] = 150
+    messages: List[ChatMessage]
+    model: Optional[str] = "gpt-4o-mini"
+    max_tokens: Optional[int] = 150
     temperature: Optional[float] = 0.7
-    reasoning_effort: Optional[str] = "medium"  # minimal, low, medium, high
-    verbosity: Optional[str] = "medium"  # low, medium, high
-    top_p: Optional[float] = None
-    stream: Optional[bool] = False
 
 class ChatCompletionResponse(BaseModel):
     message: str
     model: str
     usage: dict
-    reasoning_effort: Optional[str] = None
-    verbosity: Optional[str] = None
 
 @app.post("/chat/completions", response_model=ChatCompletionResponse)
 async def chat_completion(request: ChatCompletionRequest):
     """
-    Chat completion endpoint using OpenAI GPT-5 Nano
+    Chat completion endpoint using OpenAI GPT-4o Mini
     Makes a single chat completion API request to OpenAI
     """
     try:
@@ -50,23 +48,16 @@ async def chat_completion(request: ChatCompletionRequest):
                 detail="OpenAI API key not configured. Please set OPENAI_API_KEY environment variable."
             )
         
-        # Prepare parameters for GPT-5 Nano API call
-        api_params = {
-            "model": request.model,
-            "input": request.input,
-            "max_output_tokens": request.max_output_tokens,
-            "temperature": request.temperature,
-            "reasoning_effort": request.reasoning_effort,
-            "verbosity": request.verbosity,
-            "stream": request.stream
-        }
+        # Convert Pydantic models to dict format expected by OpenAI
+        messages = [{"role": msg.role, "content": msg.content} for msg in request.messages]
         
-        # Add optional parameters only if they're not None
-        if request.top_p is not None:
-            api_params["top_p"] = request.top_p
-        
-        # Make the OpenAI API call for GPT-5
-        response = client.chat.completions.create(**api_params)
+        # Make the OpenAI API call
+        response = client.chat.completions.create(
+            model=request.model,
+            messages=messages,
+            max_tokens=request.max_tokens,
+            temperature=request.temperature
+        )
         
         # Extract the response content
         message_content = response.choices[0].message.content
@@ -78,9 +69,7 @@ async def chat_completion(request: ChatCompletionRequest):
                 "prompt_tokens": response.usage.prompt_tokens,
                 "completion_tokens": response.usage.completion_tokens,
                 "total_tokens": response.usage.total_tokens
-            },
-            reasoning_effort=request.reasoning_effort,
-            verbosity=request.verbosity
+            }
         )
         
     except Exception as e:

--- a/main.py
+++ b/main.py
@@ -11,7 +11,7 @@ load_dotenv()
 # Create FastAPI instance
 app = FastAPI(
     title="Hello World API with OpenAI",
-    description="A FastAPI backend with hello world and OpenAI chat completion endpoints",
+    description="A FastAPI backend with hello world and OpenAI GPT-5 Nano chat completion endpoints",
     version="1.0.0"
 )
 
@@ -25,7 +25,7 @@ class ChatMessage(BaseModel):
 
 class ChatCompletionRequest(BaseModel):
     messages: List[ChatMessage]
-    model: Optional[str] = "gpt-4"
+    model: Optional[str] = "gpt-5-nano"
     max_tokens: Optional[int] = 150
     temperature: Optional[float] = 0.7
 
@@ -37,7 +37,7 @@ class ChatCompletionResponse(BaseModel):
 @app.post("/chat/completions", response_model=ChatCompletionResponse)
 async def chat_completion(request: ChatCompletionRequest):
     """
-    Chat completion endpoint using OpenAI GPT-4
+    Chat completion endpoint using OpenAI GPT-5 Nano
     Makes a single chat completion API request to OpenAI
     """
     try:

--- a/main.py
+++ b/main.py
@@ -19,20 +19,22 @@ app = FastAPI(
 client = OpenAI(api_key=os.getenv("OPENAI_API_KEY"))
 
 # Pydantic models
-class ChatMessage(BaseModel):
-    role: str
-    content: str
-
 class ChatCompletionRequest(BaseModel):
-    messages: List[ChatMessage]
+    input: str
     model: Optional[str] = "gpt-5-nano"
-    max_tokens: Optional[int] = 150
+    max_output_tokens: Optional[int] = 150
     temperature: Optional[float] = 0.7
+    reasoning_effort: Optional[str] = "medium"  # minimal, low, medium, high
+    verbosity: Optional[str] = "medium"  # low, medium, high
+    top_p: Optional[float] = None
+    stream: Optional[bool] = False
 
 class ChatCompletionResponse(BaseModel):
     message: str
     model: str
     usage: dict
+    reasoning_effort: Optional[str] = None
+    verbosity: Optional[str] = None
 
 @app.post("/chat/completions", response_model=ChatCompletionResponse)
 async def chat_completion(request: ChatCompletionRequest):
@@ -48,16 +50,23 @@ async def chat_completion(request: ChatCompletionRequest):
                 detail="OpenAI API key not configured. Please set OPENAI_API_KEY environment variable."
             )
         
-        # Convert Pydantic models to dict format expected by OpenAI
-        messages = [{"role": msg.role, "content": msg.content} for msg in request.messages]
+        # Prepare parameters for GPT-5 Nano API call
+        api_params = {
+            "model": request.model,
+            "input": request.input,
+            "max_output_tokens": request.max_output_tokens,
+            "temperature": request.temperature,
+            "reasoning_effort": request.reasoning_effort,
+            "verbosity": request.verbosity,
+            "stream": request.stream
+        }
         
-        # Make the OpenAI API call
-        response = client.chat.completions.create(
-            model=request.model,
-            messages=messages,
-            max_tokens=request.max_tokens,
-            temperature=request.temperature
-        )
+        # Add optional parameters only if they're not None
+        if request.top_p is not None:
+            api_params["top_p"] = request.top_p
+        
+        # Make the OpenAI API call for GPT-5
+        response = client.chat.completions.create(**api_params)
         
         # Extract the response content
         message_content = response.choices[0].message.content
@@ -69,7 +78,9 @@ async def chat_completion(request: ChatCompletionRequest):
                 "prompt_tokens": response.usage.prompt_tokens,
                 "completion_tokens": response.usage.completion_tokens,
                 "total_tokens": response.usage.total_tokens
-            }
+            },
+            reasoning_effort=request.reasoning_effort,
+            verbosity=request.verbosity
         )
         
     except Exception as e:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,4 @@
 fastapi==0.104.1
 uvicorn[standard]==0.24.0
+openai==1.12.0
+python-dotenv==1.0.0


### PR DESCRIPTION
Add a POST `/chat/completions` endpoint to integrate OpenAI GPT-4 chat completions.

---
<a href="https://cursor.com/background-agent?bcId=bc-01dc83db-ee5c-4079-a54f-08aed9db8c64"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-01dc83db-ee5c-4079-a54f-08aed9db8c64"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

